### PR TITLE
Restore dump synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Fixed a bug in mysql/postgres that didn't wait for the restore dump process to complete before starting the anonymize procedure
+
 ## [1.21.3] 2021-11-14
 - Added a workflow that automatically runs `black` on incoming PRs, to set a canonical standard for formatting in the project.
 - Fixed a bug in mysql/postgres where stdin is not closed after reading

--- a/pynonymizer/database/mysql/__init__.py
+++ b/pynonymizer/database/mysql/__init__.py
@@ -197,7 +197,7 @@ class MySqlProvider(DatabaseProvider):
                         batch_processor.flush()
                         bar.update(len(chunk))
         finally:
-            batch_processor.close()
+            self.__runner.close_batch_processor()
 
     def dump_database(self, output_path):
         """

--- a/pynonymizer/database/mysql/execution.py
+++ b/pynonymizer/database/mysql/execution.py
@@ -55,6 +55,7 @@ class MySqlCmdRunner:
         self.db_name = db_name
         self.db_port = db_port
         self.additional_opts = shlex.split(additional_opts)
+        self.process = None
 
         if not (shutil.which("mysql")):
             raise DependencyError(
@@ -142,7 +143,15 @@ class MySqlCmdRunner:
             self.__mask_subprocess_error(error)
 
     def open_batch_processor(self):
-        return subprocess.Popen(
+        self.close_batch_processor()
+        self.process = subprocess.Popen(
             self.__get_base_params() + self.additional_opts + [self.db_name],
             stdin=subprocess.PIPE,
-        ).stdin
+        )
+        return self.process.stdin
+
+    def close_batch_processor(self):
+        if self.process is not None:
+            self.process.stdin.close()
+            self.process.wait()
+            self.process = None

--- a/pynonymizer/database/postgres/__init__.py
+++ b/pynonymizer/database/postgres/__init__.py
@@ -196,7 +196,7 @@ class PostgreSqlProvider(DatabaseProvider):
                         batch_processor.flush()
                         bar.update(len(chunk))
         finally:
-            batch_processor.close()
+            self.__runner.close_batch_processor()
 
     def dump_database(self, output_path):
         """


### PR DESCRIPTION
Hi @rwnx,
I found out while restoring a PostgreSQL dump of ~1.5GB that pynonymizer does not wait for psql to exit before starting to anonymize data.

If the dump contains some ALTER TABLE statements that work on the same fields that should be anonymized a race condition can happen and the process slow down or stuck in a unpredictable manner.

Instead of closing STDIN while restoring the dump I've added some statements that close STDIN and wait for the command process to complete.
I think that this issue can also arise on MySQL/MariaDB and I've also adapted the command runner for this DBMS.