### PR TITLE
Add new ignore-anonymization-errors feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+- Added a new option, `--ignore-anonymization-errors` that will allow the anonymization step to error without propagating errors upstream. This is useful if you always want the resulting dumpfile, even when there are db or schema faults. 
 
 ## [1.22.0] 2022-02-06
 - Fixed a bug in mysql/postgres that didn't wait for the restore dump process to complete before starting the anonymize procedure

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ usage: pynonymizer [-h] [--input INPUT]
                    [--mysql-dump-opts MYSQL_DUMP_OPTS]
                    [--postgres-cmd-opts POSTGRES_CMD_OPTS]
                    [--postgres-dump-opts POSTGRES_DUMP_OPTS]
-                   [-v] [--verbose] [--dry-run]
+                   [-v] [--verbose] [--dry-run] 
+                   [--ignore-anonymization-errors]
 
 A tool for writing better anonymization strategies for your
 production databases.
@@ -210,6 +211,10 @@ optional arguments:
   --dry-run             Instruct pynonymizer to skip all process
                         steps. Useful for testing safely.
                         [$PYNONYMIZER_DRY_RUN]
+  --ignore-anonymization-errors
+                        Instruct pynonymizer to ignore errors during the 
+                        anonymization process and continue as normal
+                        [$PYNONYMIZER_IGNORE_ANONYMIZATION_ERRORS]
 
 ```
 ### Package

--- a/pynonymizer/cli.py
+++ b/pynonymizer/cli.py
@@ -200,6 +200,13 @@ def create_parser():
         help="Instruct pynonymizer to skip all process steps. Useful for testing safely.  [$PYNONYMIZER_DRY_RUN]",
     )
 
+    parser.add_argument(
+        "--ignore-anonymization-errors",
+        default=os.getenv("PYNONYMIZER_IGNORE_ANONYMIZATION_ERRORS") or False,
+        action="store_true",
+        help="Instruct pynonymizer to ignore errors during the anonymization process and continue as normal.  [$PYNONYMIZER_IGNORE_ANONYMIZATION_ERRORS]",
+    )
+
     return parser
 
 
@@ -292,6 +299,7 @@ def cli(rawArgs=None):
             postgres_dump_opts=args.postgres_dump_opts,
             dry_run=args.dry_run,
             verbose=args.verbose,
+            ignore_anonymization_errors=args.ignore_anonymization_errors,
         )
     except ModuleNotFoundError as error:
         if error.name == "pyodbc" and args.db_type == "mssql":

--- a/pynonymizer/pynonymize.py
+++ b/pynonymizer/pynonymize.py
@@ -28,6 +28,7 @@ def pynonymize(
     seed_rows=None,
     dry_run=False,
     verbose=False,
+    ignore_anonymization_errors=False,
     **kwargs,
 ):
     """
@@ -141,7 +142,11 @@ def pynonymize(
 
     logger.info(actions.summary(ProcessSteps.ANONYMIZE_DB))
     if not actions.skipped(ProcessSteps.ANONYMIZE_DB):
-        db_provider.anonymize_database(strategy)
+        try:
+            db_provider.anonymize_database(strategy)
+        except Exception as e:
+            if not ignore_anonymization_errors:
+                raise e
 
     logger.info(actions.summary(ProcessSteps.DUMP_DB))
     if not actions.skipped(ProcessSteps.DUMP_DB):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,7 @@ class MainArgTests(unittest.TestCase):
             postgres_cmd_opts="--additional",
             dry_run=True,
             verbose=True,
+            ignore_anonymization_errors=True,
         )
 
     @patch("os.getenv", Mock(side_effect=mock_getenv_old))
@@ -79,6 +80,7 @@ class MainArgTests(unittest.TestCase):
             postgres_cmd_opts="--additional",
             dry_run=True,
             verbose=True,
+            ignore_anonymization_errors=True,
         )
 
     def test_dotenv_called(self, pynonymize, create_parser, load_dotenv, find_dotenv):
@@ -152,6 +154,7 @@ class MainArgTests(unittest.TestCase):
             postgres_cmd_opts="--additional",
             dry_run=True,
             verbose=True,
+            ignore_anonymization_errors=True,
         )
 
 

--- a/tests/test_pynonymize.py
+++ b/tests/test_pynonymize.py
@@ -64,9 +64,6 @@ class MainProcessTests(unittest.TestCase):
     def test_pynonymize_main_process(
         self, StrategyParser, FakeColumnSet, get_provider, read_config
     ):
-        """
-        a rough smoke test for the cli process. This needs an integration test to back it up.
-        """
         pynonymize(
             input_path="TEST_INPUT",
             strategyfile_path="TEST_STRATEGYFILE",
@@ -232,6 +229,48 @@ class MainProcessTests(unittest.TestCase):
         provider.anonymize_database.assert_called()
         provider.dump_database.assert_called()
         provider.drop_database.assert_called()
+
+    def test_pynonymize__when_anonymize_raises__should_error(
+        self, StrategyParser, FakeColumnSet, get_provider, read_config
+    ):
+        get_provider.return_value.anonymize_database.side_effect = Exception(
+            "a problem!"
+        )
+        with pytest.raises(Exception):
+            pynonymize(
+                input_path="TEST_INPUT",
+                strategyfile_path="TEST_STRATEGYFILE",
+                output_path="TEST_OUTPUT",
+                db_type="TEST_TYPE",
+                db_host="TEST_HOST",
+                db_port="TEST_PORT",
+                db_name="TEST_NAME",
+                db_user="TEST_USER",
+                db_password="TEST_PASSWORD",
+                fake_locale="TEST_LOCALE",
+                seed_rows=999,
+            )
+
+    def test_pynonymize__when_ignore_errors_when_anonymize_raises__should_not_error(
+        self, StrategyParser, FakeColumnSet, get_provider, read_config
+    ):
+        get_provider.return_value.anonymize_database.side_effect = Exception(
+            "a problem!"
+        )
+        pynonymize(
+            input_path="TEST_INPUT",
+            strategyfile_path="TEST_STRATEGYFILE",
+            output_path="TEST_OUTPUT",
+            db_type="TEST_TYPE",
+            db_host="TEST_HOST",
+            db_port="TEST_PORT",
+            db_name="TEST_NAME",
+            db_user="TEST_USER",
+            db_password="TEST_PASSWORD",
+            fake_locale="TEST_LOCALE",
+            seed_rows=999,
+            ignore_anonymization_errors=True,
+        )
 
 
 @patch("dotenv.find_dotenv", Mock())


### PR DESCRIPTION
This is a very broad implementation of this feature, designed to
handle basically any error out of the anonymization step.

I haven't added any other impl of this in other step because i'm not sure
that it makes much sense for the domain - those steps can always be skipped.

Last part of implementation for #96 