### PR TITLE
Removed python36, added python310 support

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, 3.10]
+        python: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ubuntu-latest
     container: python:${{matrix.python}}-buster

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, 3.10]
 
     runs-on: ubuntu-latest
     container: python:${{matrix.python}}-buster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 - Added a new option, `--ignore-anonymization-errors` that will allow the anonymization step to error without propagating errors upstream. This is useful if you always want the resulting dumpfile, even when there are db or schema faults. 
+- Removed offical test support for python 3.6
+- Added offical test support for python 3.10
 
 ## [1.22.0] 2022-02-06
 - Fixed a bug in mysql/postgres that didn't wait for the restore dump process to complete before starting the anonymize procedure

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 import setuptools
 import sys
 
-if sys.version_info < (3, 6):
-    sys.exit("pynonymizer requires Python 3.6+ to run")
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
@@ -21,10 +18,10 @@ setuptools.setup(
         "Operating System :: POSIX",
         "Topic :: Database",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     author="Rowan Twell",
     author_email="rxntwe@gmail.com",


### PR DESCRIPTION
since python36 is out of lifeycle, i don't consider this a breaking change.
additionally, python36 should theoretically continue to function,
it's just that we wont be commiting a lot of test time to it.

Closes #102 