### PR TITLE
Remove GET_SOURCE step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a new option, `--ignore-anonymization-errors` that will allow the anonymization step to error without propagating errors upstream. This is useful if you always want the resulting dumpfile, even when there are db or schema faults. 
 - Removed offical test support for python 3.6
 - Added offical test support for python 3.10
+- Removed process step `GET_SOURCE`(no-op) as it was causing confusion. This is not considered a breaking change as it was never implemented.
 
 ## [1.22.0] 2022-02-06
 - Fixed a bug in mysql/postgres that didn't wait for the restore dump process to complete before starting the anonymize procedure

--- a/doc/process-control.md
+++ b/doc/process-control.md
@@ -20,7 +20,6 @@ Pynonymize offers a few of options for controlling the process.
 ## Steps
 Pynonymizer's process is broken into steps:
   - `START`: NOOP action, first
-  - `GET_SOURCE`: Fetch input (future)
   - `CREATE_DB`: Create the named database
   - `RESTORE_DB`: Restore the database from input 
   - `ANONYMIZE_DB`: Run the anonymization process

--- a/pynonymizer/process_steps.py
+++ b/pynonymizer/process_steps.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class ProcessSteps(Enum):
     START = 0
-    GET_SOURCE = 100
     CREATE_DB = 200
     RESTORE_DB = 300
     ANONYMIZE_DB = 400

--- a/tests/test_pynonymize.py
+++ b/tests/test_pynonymize.py
@@ -286,7 +286,6 @@ class OptionalArgumentsSkippedTests(unittest.TestCase):
     that are only mandatory for certain steps.
 
     START = 0
-    GET_SOURCE = 100
     CREATE_DB = 200
     RESTORE_DB = 300
     ANONYMIZE_DB = 400


### PR DESCRIPTION
* this step was never implemented and was a remnant.
* I'm not considering this change to be breaking as it was a no-op.
* this feature has actively caused confusion and that's why we're removing it.