### PR TITLE
mysql: make server config optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+### Changed
+- In MySQL,`db_host`, `db_user`, `db_pass` and `db_port` are now optional and will be omitted from CLI options if not passed to pynonymizer. 
+  This is to facilitate usage of provider-specific config formats like `my.cnf` [#108]
 
 ## [1.23.0] 2022-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 ### Changed
-- In MySQL,`db_host`, `db_user`, `db_pass` and `db_port` are now optional and will be omitted from CLI options if not passed to pynonymizer. 
-  This is to facilitate usage of provider-specific config formats like `my.cnf` [#108]
+- In MySQL,`db_host`, `db_user`, `db_pass` and `db_port` are now optional and will be omitted from CLI options if not passed.
+  You can now use the `my.cnf` file to pass config to the mysql CLI. [#108]
+- In Postgres, `db_pass` will be optional and will be omitted from CLI options if not passed. You can now use the `.pgpass` file to securely pass the password to the pg CLI.
 
 ## [1.23.0] 2022-08-22
 ### Added

--- a/doc/database-credentials.md
+++ b/doc/database-credentials.md
@@ -1,0 +1,22 @@
+# Database Credentials
+Pynonymizer requires a connection to a real database in order to perform it's work. 
+
+In most cases (mysql + postgres), pynonymizer uses the databases' CLI tooling to send commands. 
+You might have seen something like this:
+
+```
+mysql: [Warning] Using a password on the command line interface can be insecure.
+```
+
+This occurs because pynonymizer is passing the database password to the CLI using the `-p` option. This means that the password could be visible to other users with access to the running process, e.g. via `ps`.
+
+The same is true for config passed directly to pynonymizer. 
+
+## How do I stop this?
+As pynonymizer uses the CLI, the CLI's normal mechanisms for this will also work. 
+
+For providers (mysql and postgres) that allow external configuration, `--db-user` and `--db-pass` will be optional, to support loading credentials through the relevant file:
+    * mysql: `my.cnf`/`*.cnf` files: https://dev.mysql.com/doc/refman/8.0/en/option-files.html
+    * postgres: `.pgpass` file https://www.postgresql.org/docs/current/libpq-pgpass.html
+    * mssql: Not currently supported. 
+

--- a/pynonymizer/database/mysql/execution.py
+++ b/pynonymizer/database/mysql/execution.py
@@ -18,11 +18,11 @@ def _optional_arg_pair(arg_value_pair):
 class MySqlDumpRunner:
     def __init__(
         self,
-        db_host=None,
-        db_user=None,
-        db_pass=None,
-        db_name=None,
-        db_port=None,
+        db_host,
+        db_user,
+        db_pass,
+        db_name,
+        db_port,
         additional_opts="",
     ):
         self.db_host = db_host
@@ -67,11 +67,11 @@ class MySqlDumpRunner:
 class MySqlCmdRunner:
     def __init__(
         self,
-        db_host=None,
-        db_user=None,
-        db_pass=None,
-        db_name=None,
-        db_port=None,
+        db_host,
+        db_user,
+        db_pass,
+        db_name,
+        db_port,
         additional_opts="",
     ):
         self.db_host = db_host

--- a/pynonymizer/database/mysql/execution.py
+++ b/pynonymizer/database/mysql/execution.py
@@ -3,14 +3,27 @@ import shlex
 import subprocess
 from pynonymizer.database.exceptions import DependencyError
 
-"""
-Seperate everything that touches actual query exec into its own module
-"""
+
+def _optional_arg(condition, value):
+    if condition:
+        return value
+    else:
+        return []
+
+
+def _optional_arg_pair(arg_value_pair):
+    return _optional_arg(arg_value_pair[1], arg_value_pair)
 
 
 class MySqlDumpRunner:
     def __init__(
-        self, db_host, db_user, db_pass, db_name, db_port="3306", additional_opts=""
+        self,
+        db_host=None,
+        db_user=None,
+        db_pass=None,
+        db_name=None,
+        db_port=None,
+        additional_opts="",
     ):
         self.db_host = db_host
         self.db_user = db_user
@@ -19,20 +32,26 @@ class MySqlDumpRunner:
         self.db_port = db_port
         self.additional_opts = shlex.split(additional_opts)
 
+        if db_name is None:
+            raise ValueError("db_name cannot be null")
+
         if not (shutil.which("mysqldump")):
             raise DependencyError(
                 "mysqldump", "The 'mysqldump' client must be present in the $PATH"
             )
 
+    def __ifdef(self):
+        if self.db_host:
+            return ["--host", self.db_host]
+        else:
+            return []
+
     def __get_base_params(self):
         return [
-            "--host",
-            self.db_host,
-            "--port",
-            self.db_port,
-            "--user",
-            self.db_user,
-            f"-p{self.db_pass}",
+            *_optional_arg_pair(["--host", self.db_host]),
+            *_optional_arg_pair(["--port", self.db_port]),
+            *_optional_arg_pair(["--user", self.db_user]),
+            *_optional_arg(self.db_pass, [f"-p{self.db_pass}"]),
         ]
 
     def open_dumper(self):
@@ -47,7 +66,13 @@ class MySqlDumpRunner:
 
 class MySqlCmdRunner:
     def __init__(
-        self, db_host, db_user, db_pass, db_name, db_port="3306", additional_opts=""
+        self,
+        db_host=None,
+        db_user=None,
+        db_pass=None,
+        db_name=None,
+        db_port=None,
+        additional_opts="",
     ):
         self.db_host = db_host
         self.db_user = db_user
@@ -56,6 +81,9 @@ class MySqlCmdRunner:
         self.db_port = db_port
         self.additional_opts = shlex.split(additional_opts)
         self.process = None
+
+        if db_name is None:
+            raise ValueError("db_name cannot be null")
 
         if not (shutil.which("mysql")):
             raise DependencyError(
@@ -84,13 +112,10 @@ class MySqlCmdRunner:
     def __get_base_params(self):
         return [
             "mysql",
-            "-h",
-            self.db_host,
-            "-P",
-            self.db_port,
-            "-u",
-            self.db_user,
-            f"-p{self.db_pass}",
+            *_optional_arg_pair(["-h", self.db_host]),
+            *_optional_arg_pair(["-P", self.db_port]),
+            *_optional_arg_pair(["-u", self.db_user]),
+            *_optional_arg(self.db_pass, [f"-p{self.db_pass}"]),
         ]
 
     def execute(self, statements):

--- a/pynonymizer/database/postgres/execution.py
+++ b/pynonymizer/database/postgres/execution.py
@@ -38,7 +38,8 @@ class PSqlDumpRunner:
 
     def __get_env(self):
         new_env = os.environ.copy()
-        new_env.update({"PGPASSWORD": self.db_pass})
+        if self.db_pass:
+            new_env.update({"PGPASSWORD": self.db_pass})
 
         return new_env
 
@@ -80,7 +81,8 @@ class PSqlCmdRunner:
 
     def __get_env(self):
         new_env = os.environ.copy()
-        new_env.update({"PGPASSWORD": self.db_pass})
+        if self.db_pass:
+            new_env.update({"PGPASSWORD": self.db_pass})
 
         return new_env
 

--- a/pynonymizer/pynonymize.py
+++ b/pynonymizer/pynonymize.py
@@ -90,8 +90,10 @@ def pynonymize(
         if db_user is None:
             validations.append("Missing DB_USER")
 
-        if db_password is None:
-            validations.append("Missing DB_PASSWORD")
+        # postgres supports implicit db_pass using the .pgpass file
+        if db_type != "postgres":
+            if db_password is None:
+                validations.append("Missing DB_PASSWORD")
 
     if db_name is None:
         validations.append("Missing DB_NAME: Auto-resolve failed.")

--- a/pynonymizer/pynonymize.py
+++ b/pynonymizer/pynonymize.py
@@ -85,11 +85,13 @@ def pynonymize(
         if output_path is None:
             validations.append("Missing OUTPUT")
 
-    if db_user is None:
-        validations.append("Missing DB_USER")
+    # Mysql supports my.cnf files with additional config, so we have to assume db_host, db_user, db_password, db_port could all be in there
+    if db_type != "mysql":
+        if db_user is None:
+            validations.append("Missing DB_USER")
 
-    if db_password is None:
-        validations.append("Missing DB_PASSWORD")
+        if db_password is None:
+            validations.append("Missing DB_PASSWORD")
 
     if db_name is None:
         validations.append("Missing DB_NAME: Auto-resolve failed.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,3 +66,18 @@ def simple_strategy(
     return DatabaseStrategy(
         [simple_strategy_trunc, simple_strategy_update, simple_strategy_delete]
     )
+
+
+# MONKEYPATCH: assert_not_called_with
+def assert_not_called_with(self, *args, **kwargs):
+    try:
+        self.assert_called_with(*args, **kwargs)
+    except AssertionError:
+        return
+    raise AssertionError(
+        "Expected %s to not have been called."
+        % self._format_mock_call_signature(args, kwargs)
+    )
+
+
+Mock.assert_not_called_with = assert_not_called_with

--- a/tests/database/mysql/test_execution.py
+++ b/tests/database/mysql/test_execution.py
@@ -10,11 +10,11 @@ import subprocess
 class NoExecutablesInPathTests(unittest.TestCase):
     def test_dump_runner_missing_mysqldump(self):
         with pytest.raises(DependencyError):
-            MySqlDumpRunner("1.2.3.4", "user", "password", "name")
+            MySqlDumpRunner("1.2.3.4", "user", "password", "name", db_port=None)
 
     def test_cmd_runner_missing_mysql(self):
         with pytest.raises(DependencyError):
-            MySqlCmdRunner("1.2.3.4", "user", "password", "name")
+            MySqlCmdRunner("1.2.3.4", "user", "password", "name", db_port=None)
 
 
 @patch("subprocess.Popen")
@@ -29,6 +29,7 @@ class DumperTests(unittest.TestCase):
             db_user=None,
             db_pass=None,
             db_name="db_name",
+            db_port=None,
             additional_opts="--quick --single-transaction",
         )
 
@@ -49,10 +50,11 @@ class DumperTests(unittest.TestCase):
         self, check_output, popen
     ):
         dump_runner = MySqlDumpRunner(
-            "1.2.3.4",
-            "db_user",
-            "db_password",
-            "db_name",
+            db_host="1.2.3.4",
+            db_user="db_user",
+            db_pass="db_password",
+            db_name="db_name",
+            db_port=None,
             additional_opts="--quick --single-transaction",
         )
 
@@ -77,7 +79,13 @@ class DumperTests(unittest.TestCase):
     def test_open_dumper__when_port_is_not_passed__should_use_defaults(
         self, check_output, popen
     ):
-        dump_runner = MySqlDumpRunner("1.2.3.4", "db_user", "db_password", "db_name")
+        dump_runner = MySqlDumpRunner(
+            db_host="1.2.3.4",
+            db_user="db_user",
+            db_pass="db_password",
+            db_name="db_name",
+            db_port=None,
+        )
         open_result = dump_runner.open_dumper()
 
         # dumper should open a process for the current db dump, piping stdout for processing
@@ -137,6 +145,7 @@ class CmdTests(unittest.TestCase):
             db_pass=None,
             db_name="db_name",
             db_host=None,
+            db_port=None,
             additional_opts="--quick --single-transaction",
         )
         open_result = cmd_runner.open_batch_processor()
@@ -191,6 +200,7 @@ class CmdTests(unittest.TestCase):
             db_pass=None,
             db_name="db_name",
             db_host=None,
+            db_port=None,
             additional_opts="--quick --single-transaction",
         )
         execute_result = cmd_runner.execute("SELECT `column` from `table`;")

--- a/tests/test_pynonymize.py
+++ b/tests/test_pynonymize.py
@@ -10,17 +10,6 @@ from pynonymizer.pynonymize import (
 from types import SimpleNamespace
 
 
-def test_pynonymize_missing_db_credentials():
-    with pytest.raises(ArgumentValidationError):
-        pynonymize(
-            input_path="input.sql",
-            strategyfile_path="strategyfile.yml",
-            output_path="output.sql",
-            db_user=None,
-            db_password=None,
-        )
-
-
 @patch("dotenv.find_dotenv", Mock())
 @patch("dotenv.load_dotenv", Mock())
 @patch("pynonymizer.pynonymize.read_config")
@@ -29,12 +18,9 @@ def test_pynonymize_missing_db_credentials():
 @patch("pynonymizer.pynonymize.StrategyParser")
 @patch("builtins.open", mock_open(read_data="TESTFILEDATA"))
 class MainProcessTests(unittest.TestCase):
-    def test_any_db_kwarg(
+    def test_dynamic_db_args_passed_to_provder_unprefixed(
         self, StrategyParser, FakeColumnSet, get_provider, read_config
     ):
-        """
-        test that dynamic args are passed to the provider properly e.g. mssql_blah
-        """
         pynonymize(
             input_path="TEST_INPUT",
             strategyfile_path="TEST_STRATEGYFILE",

--- a/tests_integration/mysql/test_mysql.py
+++ b/tests_integration/mysql/test_mysql.py
@@ -1,12 +1,57 @@
 import pytest
 import subprocess
 import os
+import unittest
 
 # force getenv to error here for more human-readable errors
 user = os.getenv("PYNONYMIZER_DB_USER")
 password = os.getenv("PYNONYMIZER_DB_PASSWORD")
 test_dir = os.path.dirname(os.path.realpath(__file__))
 ONE_MB = 1024 * 1024
+
+home = os.path.expanduser("~")
+config_path = os.path.join(home, ".my.cnf")
+
+
+class OptionalConfigTests(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+
+        with open(config_path, "w+") as f:
+            f.write(
+                f"""
+[client]
+user="{user}"
+password="{password}"
+                """
+            )
+
+    def test_smoke_lzma(self):
+        # remove db user/password from env (used in other tests)
+        new_env = os.environ.copy()
+        del new_env["PYNONYMIZER_DB_USER"]
+        del new_env["PYNONYMIZER_DB_PASSWORD"]
+        output_path = os.path.join(test_dir, "./OptionalConfig.sql.xz")
+        output = subprocess.check_output(
+            [
+                "pynonymizer",
+                "-i",
+                "sakila.sql.gz",
+                "-o",
+                output_path,
+                "-s",
+                "sakila.yml",
+            ],
+            cwd=test_dir,
+            env=new_env,
+        )
+
+        # some very rough output checks
+        assert os.path.exists(output_path)
+
+    @classmethod
+    def teardown_class(cls):
+        os.remove(config_path)
 
 
 def test_smoke_lzma():


### PR DESCRIPTION
This is to support usage of local config files (my.cnf) see  #108


* I've skipped postgres because i need to investigate more about the pgpass file. I think we still need to pass a lot of config, only the password can be replaced
* I've skipped mssql because we're not using the CLI, so no cli-behaviour can be expected
* Needs: a closer look at an integration test