### PR TITLE
Optimization of Fake Update strategy on Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+### Changed
+- In Postgres, improved the FAKE_UPDATE strategy performances
 
 ## [1.24.0] 2022-09-07
 ### Changed
@@ -39,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.22.0] 2022-02-06
 ### Changed
-- Changed anonymization process to attempt to attempt anonymize all tables before throwing errors. [#96]
+- Changed anonymization process to attempt to anonymize all tables before throwing errors. [#96]
 ### Fixed
 - Fixed a bug in mysql/postgres that didn't wait for the restore dump process to complete before starting the anonymize procedure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   -------------------------------------------------------------------
 ## [Unreleased]
 ### Changed
-- In Postgres, improved the FAKE_UPDATE strategy performances
+- Postgres FAKE_UPDATE strategy now uses an id-based randomization to pick from the seed table. 
+  This speeds up updates on large tables, as the seed table no longer needs to be ordered for every row in the target table.
+  Also this makes performances less dependent on the length of the seed table.
 
 ## [1.24.0] 2022-09-07
 ### Changed

--- a/pynonymizer/database/postgres/query_factory.py
+++ b/pynonymizer/database/postgres/query_factory.py
@@ -16,6 +16,12 @@ _FAKE_COLUMN_TYPES = {
 # Random text function
 _RAND_MD5 = "md5(random()::text)"
 
+# Pseudo random integer function
+_PSEUDO_RANDOM_INT = "ABS(('x' || MD5(updatetarget::text))::bit(32)::int)"
+
+# Seed Table Id column name
+_ID = "_id"
+
 
 def _get_sql_type(data_type):
     return _FAKE_COLUMN_TYPES[data_type]
@@ -32,7 +38,11 @@ def _get_column_subquery(seed_table_name, column_strategy):
         column = f'"{column_strategy.qualifier}"'
         if column_strategy.sql_type:
             column += "::" + column_strategy.sql_type
-        return f'( SELECT {column} FROM "{seed_table_name}" ORDER BY RANDOM(), MD5("updatetarget"::text) LIMIT 1)'
+
+        num_rows = f'(SELECT MAX("{_ID}") FROM "{seed_table_name}")'
+        pseudo_random_row_id = f"MOD({_PSEUDO_RANDOM_INT}, {num_rows}) + 1"
+
+        return f'( SELECT {column} FROM "{seed_table_name}" WHERE "{_ID}"={pseudo_random_row_id})'
     elif column_strategy.strategy_type == UpdateColumnStrategyTypes.LITERAL:
         return column_strategy.value
     else:
@@ -68,7 +78,8 @@ def get_create_seed_table(table_name, qualifier_map):
     if len(qualifier_map) < 1:
         raise ValueError("Cannot create a seed table with no columns")
 
-    create_columns = [
+    create_columns = [f"{_ID} SERIAL NOT NULL PRIMARY KEY"]
+    create_columns += [
         f"{qualifier} {_get_sql_type(strategy.data_type)}"
         for qualifier, strategy in qualifier_map.items()
     ]

--- a/pynonymizer/database/postgres/query_factory.py
+++ b/pynonymizer/database/postgres/query_factory.py
@@ -92,7 +92,6 @@ def get_drop_seed_table(table_name):
 
 
 def get_insert_seed_row(table_name, qualifier_map):
-
     column_names = ",".join([f"{qualifier}" for qualifier in qualifier_map.keys()])
     column_values = ",".join(
         [f"{_escape_sql_value(strategy.value)}" for strategy in qualifier_map.values()]

--- a/tests/database/postgres/test_query_factory.py
+++ b/tests/database/postgres/test_query_factory.py
@@ -210,7 +210,7 @@ def test_get_insert_seed_row(qualifier_column_map):
 def test_get_create_seed_table(qualifier_column_map):
     assert (
         query_factory.get_create_seed_table("seed_table", qualifier_column_map)
-        == 'CREATE TABLE "seed_table" (first_name VARCHAR(65535),last_name INT,first_name_test_arg_5 VARCHAR(65535));'
+        == 'CREATE TABLE "seed_table" (_id SERIAL NOT NULL PRIMARY KEY,first_name VARCHAR(65535),last_name INT,first_name_test_arg_5 VARCHAR(65535));'
     )
 
 
@@ -237,9 +237,9 @@ def test_get_update_table_fake_column(column_strategy_list):
 
     assert update_table_all == [
         'UPDATE "anon_table" AS "updatetarget" SET '
-        '"test_column1" = ( SELECT "first_name" FROM "seed_table" ORDER BY RANDOM(), MD5("updatetarget"::text) LIMIT 1),'
-        '"test_column2" = ( SELECT "last_name" FROM "seed_table" ORDER BY RANDOM(), MD5("updatetarget"::text) LIMIT 1),'
-        '"test_column7" = ( SELECT "user_id"::UUID FROM "seed_table" ORDER BY RANDOM(), MD5("updatetarget"::text) LIMIT 1),'
+        '"test_column1" = ( SELECT "first_name" FROM "seed_table" WHERE "_id"=MOD(ABS((\'x\' || MD5(updatetarget::text))::bit(32)::int), (SELECT MAX("_id") FROM "seed_table")) + 1),'
+        '"test_column2" = ( SELECT "last_name" FROM "seed_table" WHERE "_id"=MOD(ABS((\'x\' || MD5(updatetarget::text))::bit(32)::int), (SELECT MAX("_id") FROM "seed_table")) + 1),'
+        '"test_column7" = ( SELECT "user_id"::UUID FROM "seed_table" WHERE "_id"=MOD(ABS((\'x\' || MD5(updatetarget::text))::bit(32)::int), (SELECT MAX("_id") FROM "seed_table")) + 1),'
         "\"test_column3\" = (''),"
         '"test_column4" = ( SELECT md5(random()::text) ORDER BY MD5("updatetarget"::text) LIMIT 1),'
         "\"test_column5\" = ( SELECT CONCAT(md5(random()::text), '@', md5(random()::text), '.com') ORDER BY MD5(\"updatetarget\"::text) LIMIT 1),"


### PR DESCRIPTION
The subquery used to pick a random row in the Seed Table was slow since it required sorting the Seed Table for every row to update in the Target table.

This PR proposes an optimized method for picking a random row in the Seed Table.
The tradeoff is that it is pseudo random, not truly random.

The idea is:
* add a sequential ID to the Seed Table
* for every value to be updated, calculate its MD5
* then convert it into an integer
* take the absolute value in order to only have positive values
* then use the modulo to cap this integer within the range of the Seed Table ids
* then pick the row in the Seed Table with that ID

We achieved significant speed ups with this method, for instance a particular table that would take about 17 min to anonymize with the previous query only takes 16s now