### PR TITLE
Add better error messages for Unsupported fake_update types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+### Added
+- Better error messages for unsupported fake types - the error should now explain the problem and link to the docs in the right section. [#133]
+
 ## [1.25.0] 2023-03-29
 ### Changed
 - Postgres FAKE_UPDATE strategy now uses an id-based randomization to pick from the seed table. 

--- a/pynonymizer/cli.py
+++ b/pynonymizer/cli.py
@@ -333,11 +333,12 @@ def cli(rawArgs=None):
         parser.print_help()
         sys.exit(2)
     except UnsupportedFakeTypeError as error:
-        logger.error(f"There was an error while parsing the strategyfile. Unknown fake type: {error.fake_type} \n " 
-                     + f"This happens when an fake_update column strategy is used with a generator that doesn't exist. \n"
-                     + f"You can only use data types that Faker supports. \n"
-                     + f"See https://github.com/rwnx/pynonymizer/blob/master/doc/strategyfiles.md#column-strategy-fake_update for usage information."
-                     )
+        logger.error(
+            f"There was an error while parsing the strategyfile. Unknown fake type: {error.fake_type} \n "
+            + f"This happens when an fake_update column strategy is used with a generator that doesn't exist. \n"
+            + f"You can only use data types that Faker supports. \n"
+            + f"See https://github.com/rwnx/pynonymizer/blob/master/doc/strategyfiles.md#column-strategy-fake_update for usage information."
+        )
         sys.exit(1)
 
 

--- a/pynonymizer/cli.py
+++ b/pynonymizer/cli.py
@@ -3,6 +3,7 @@ import dotenv
 import os
 import sys
 import logging
+from pynonymizer.fake import UnsupportedFakeTypeError
 from pynonymizer.pynonymize import (
     ArgumentValidationError,
     DatabaseConnectionError,
@@ -331,6 +332,13 @@ def cli(rawArgs=None):
         )
         parser.print_help()
         sys.exit(2)
+    except UnsupportedFakeTypeError as error:
+        logger.error(f"There was an error while parsing the strategyfile. Unknown fake type: {error.fake_type} \n " 
+                     + f"This happens when an fake_update column strategy is used with a generator that doesn't exist. \n"
+                     + f"You can only use data types that Faker supports. \n"
+                     + f"See https://github.com/rwnx/pynonymizer/blob/master/doc/strategyfiles.md#column-strategy-fake_update for usage information."
+                     )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pynonymizer/fake/__init__.py
+++ b/pynonymizer/fake/__init__.py
@@ -50,7 +50,7 @@ _FAKE_DATA_TYPES = {
 class UnsupportedFakeTypeError(Exception):
     def __init__(self, fake_type, kwargs=None):
         kwargs = {} if kwargs is None else kwargs
-        super().__init__(f"Unsupported Fake type: {fake_type}: {kwargs.keys()}")
+        super().__init__(f"Unsupported Fake type: {fake_type}")
         self.fake_type = fake_type
         self.kwargs = kwargs
 


### PR DESCRIPTION
I dont have a good solution for finding the exact problem but i think this error message will make a lot more sense!

the error looks something like this:

```
❯ pynonymizer -i tests_integration/mysql/sakila.sql.gz -o out.sql -s tests_integration/mysql/sakila.yml
There was an error while parsing the strategyfile. Unknown fake type: name_email
 This happens when an fake_update column strategy is used with a generator that doesn't exist.
You can only use data types that Faker supports.
See https://github.com/rwnx/pynonymizer/blob/master/doc/strategyfiles.md#column-strategy-fake_update for usage information.
```