### PR TITLE
MSSQL command timeout parameter

### DIFF
--- a/pynonymizer/cli.py
+++ b/pynonymizer/cli.py
@@ -146,7 +146,7 @@ def default(
         int,
         typer.Option(
             "--mssql-timeout",
-            help="[mssql] set the query timeout option in seconds. A value of 0 leaves this values at the default."
+            help="[mssql] set the query timeout option in seconds. This is used when anonymizing the data. A value of 0 leaves this setting at the default."
         )
     ] = None,
     mysql_cmd_opts: Annotated[

--- a/pynonymizer/cli.py
+++ b/pynonymizer/cli.py
@@ -142,6 +142,13 @@ def default(
             help="[mssql] turn off ANSI_WARNINGS when making updates.",
         ),
     ] = True,
+    mssql_timeout: Annotated[
+        int,
+        typer.Option(
+            "--mssql-timeout",
+            help="[mssql] set the query timeout option in seconds. A value of 0 leaves this values at the default."
+        )
+    ] = None,
     mysql_cmd_opts: Annotated[
         str,
         typer.Option(
@@ -259,6 +266,7 @@ def default(
             db_workers=db_workers,
             mssql_connection_string=mssql_connection_string,
             mssql_ansi_warnings_off=mssql_ansi_warnings_off,
+            mssql_timeout=mssql_timeout
         )
     except ModuleNotFoundError as error:
         if error.name == "pyodbc" and db_type == "mssql":

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -142,6 +142,7 @@ class MsSqlProvider:
     def __execute(self, statement, *args):
         logger.debug(statement, args)
         c = self.__connection()
+        # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout
         return c.execute(statement, *args)
@@ -149,6 +150,7 @@ class MsSqlProvider:
     def __db_execute(self, statement, *args):
         logger.debug(statement, args)
         c = self.__db_connection()
+        # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout        
         return c.execute(statement, *args)

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -55,6 +55,7 @@ class MsSqlProvider:
         backup_compression=False,
         driver=None,
         ansi_warnings_off=True,
+        timeout=None
     ):
         # import here for fast-failiness
         import pyodbc
@@ -95,6 +96,7 @@ class MsSqlProvider:
         self.__db_conn = None
         self.__backup_compression = backup_compression
         self.ansi_warnings_off = ansi_warnings_off
+        self.timeout = timeout
 
         logger.debug("connnectionstr: %s", self.connnectionstr)
 
@@ -139,11 +141,17 @@ class MsSqlProvider:
 
     def __execute(self, statement, *args):
         logger.debug(statement, args)
-        return self.__connection().execute(statement, *args)
+        c = self.__connection()
+        if self.timeout:
+            c.timeout = self.timeout
+        return c.execute(statement, *args)
 
     def __db_execute(self, statement, *args):
         logger.debug(statement, args)
-        return self.__db_connection().execute(statement, *args)
+        c = self.__db_connection()
+        if self.timeout:
+            c.timeout = self.timeout        
+        return c.execute(statement, *args)
 
     def __get_path(self, filepath):
         if "\\" in filepath:


### PR DESCRIPTION
I was having timeout issues when anonymizing larger tables (~30M rows) with MSSQL. So I've implemented a new --mssql-timeout parameter that sets the command timeout for the UPDATE statements that run when masking data.

I've done this as a MSSQL-specific parameter mainly because I don't have a decent test setup for MySQL or Postgres with large volumes of data. Also, the implementation relies on the way PyODBC picks up the 'timeout' property of the Connection when executing SQL, so it wouldn't work for the other two database types.

I hope this is useful to other people!
