### PR TITLE
MSSQL: Handle updates that return multiple resultsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   -------------------------------------------------------------------
 ## [Unreleased]
+## Fixed
+- Fixed a issue when updates to MSSQL data would result in multiple messages coming back from the server, e.g. when triggers update multiple tables and NOCOUNT is OFF. Another scenario is before or after scripts that call stored procs wth PRINT statements in them or that return multiple resultsets before completing. Without the fix, this issue can result in tables only partially anonymized.
 
 ## [2.4.0] 2024-07-30
 ## Changed

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -142,7 +142,12 @@ class MsSqlProvider:
         # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout
-        return c.execute(statement, *args)
+        cur = c.execute(statement, *args)
+        # If the SQL query causes multiple messages to come back (either extra row counts from triggers, or PRINT statements),
+        # then we need to keep running nextset() for PyODBC to get the query to run to completion
+        while cur.nextset():
+            pass
+        return cur
 
     def __db_execute(self, statement, *args):
         logger.debug(statement, args)
@@ -150,7 +155,12 @@ class MsSqlProvider:
         # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout
-        return c.execute(statement, *args)
+        # If the SQL query causes multiple messages to come back (either extra row counts from triggers, or PRINT statements),
+        # then we need to keep running nextset() for PyODBC to get the query to run to completion
+        cur = c.execute(statement, *args)
+        while cur.nextset():
+            pass
+        return cur
 
     def __get_path(self, filepath):
         if "\\" in filepath:

--- a/pynonymizer/database/mssql/__init__.py
+++ b/pynonymizer/database/mssql/__init__.py
@@ -136,9 +136,9 @@ class MsSqlProvider:
 
         return self.__db_conn
 
-    def __execute(self, statement, *args):
+    def __execute_dml(self, statement, *args):
         logger.debug(statement, args)
-        c = self.__connection()
+        c = self.__db_connection()
         # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout
@@ -149,18 +149,21 @@ class MsSqlProvider:
             pass
         return cur
 
-    def __db_execute(self, statement, *args):
+    def __execute_ddl(self, statement, *args):
         logger.debug(statement, args)
         c = self.__db_connection()
         # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
         if self.timeout:
             c.timeout = self.timeout
-        # If the SQL query causes multiple messages to come back (either extra row counts from triggers, or PRINT statements),
-        # then we need to keep running nextset() for PyODBC to get the query to run to completion
-        cur = c.execute(statement, *args)
-        while cur.nextset():
-            pass
-        return cur
+        return c.execute(statement, *args)
+    
+    def __execute_server(self, statement, *args):
+        logger.debug(statement, args)
+        c = self.__connection()
+        # If timeout is set, then apply it to the connection. PyODBC will then assign that value to the Cursor created during execute()
+        if self.timeout:
+            c.timeout = self.timeout
+        return c.execute(statement, *args)    
 
     def __get_path(self, filepath):
         if "\\" in filepath:
@@ -179,7 +182,7 @@ class MsSqlProvider:
         checking the model db seems like a good 'boring' solution
         :return: Default data directory e.g. "C:\\DATA"
         """
-        datafile = self.__execute(
+        datafile = self.__execute_server(
             """
         SELECT physical_name
         FROM sys.master_files mf
@@ -197,7 +200,7 @@ class MsSqlProvider:
         __get_default_datafolder: see for more info
         :return:
         """
-        logfile = self.__execute(
+        logfile = self.__execute_server(
             """
         SELECT physical_name
         FROM sys.master_files mf
@@ -217,7 +220,7 @@ class MsSqlProvider:
         datadir = self.__get_default_datafolder()
         logdir = self.__get_default_logfolder()
 
-        filelist = self.__execute(
+        filelist = self.__execute_server(
             f"RESTORE FILELISTONLY FROM DISK = ?;", input_path
         ).fetchall()
 
@@ -255,7 +258,7 @@ class MsSqlProvider:
 
         for i, script in enumerate(script_list):
             logger.info(f'Running {title} script #{i} "{script[:50]}"')
-            cursor = self.__db_execute(script)
+            cursor = self.__execute_dml(script)
             results = None
             try:
                 results = cursor.fetchall()
@@ -272,10 +275,10 @@ class MsSqlProvider:
             SEED_TABLE_NAME, ",".join(seed_column_lines)
         )
 
-        self.__db_execute(create_statement)
+        self.__execute_ddl(create_statement)
 
     def __drop_seed_table(self):
-        self.__db_execute("DROP TABLE IF EXISTS [{}];".format(SEED_TABLE_NAME))
+        self.__execute_ddl("DROP TABLE IF EXISTS [{}];".format(SEED_TABLE_NAME))
 
     def __insert_seed_row(self, qualifier_map):
         column_list = ",".join(
@@ -289,7 +292,7 @@ class MsSqlProvider:
         statement = "INSERT INTO [{}]({}) VALUES ({});".format(
             SEED_TABLE_NAME, column_list, substitution_list
         )
-        self.__db_execute(statement, value_list)
+        self.__execute_dml(statement, value_list)
 
     def __seed(self, qualifier_map):
         for i in self.progress(
@@ -322,10 +325,10 @@ class MsSqlProvider:
 
     def drop_database(self):
         # force connection close so we can always drop the db: sometimes timing makes a normal drop impossible.
-        self.__execute(
+        self.__execute_server(
             f"ALTER DATABASE [{self.db_name}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;"
         )
-        self.__execute(f"DROP DATABASE IF EXISTS [{self.db_name}];")
+        self.__execute_server(f"DROP DATABASE IF EXISTS [{self.db_name}];")
 
     def anonymize_database(self, database_strategy, db_workers):
         qualifier_map = database_strategy.fake_update_qualifier_map
@@ -353,13 +356,13 @@ class MsSqlProvider:
 
                 if table_strategy.strategy_type == TableStrategyTypes.TRUNCATE:
                     progressbar.set_description("Truncating {}".format(table_name))
-                    self.__db_execute(
+                    self.__execute_dml(
                         "TRUNCATE TABLE {}[{}];".format(schema_prefix, table_name)
                     )
 
                 elif table_strategy.strategy_type == TableStrategyTypes.DELETE:
                     progressbar.set_description("Deleting {}".format(table_name))
-                    self.__db_execute(
+                    self.__execute_dml(
                         "DELETE FROM {}[{}];".format(schema_prefix, table_name)
                     )
 
@@ -396,7 +399,7 @@ class MsSqlProvider:
 
                         # set ansi warnings off because otherwise we run into lots of little incompatibilities between the seed data nd the columns
                         # e.g. string or binary data would be truncated (when the data is too long)
-                        self.__db_execute(
+                        self.__execute_dml(
                             f"{ansi_warnings_prefix} UPDATE {schema_prefix}[{table_name}] SET {column_assignments}{where_clause}; {ansi_warnings_suffix}"
                         )
 
@@ -436,7 +439,7 @@ class MsSqlProvider:
         move_clauses = ", ".join(["MOVE ? TO ?"] * len(move_files))
         move_clause_params = [item for pair in move_files.items() for item in pair]
 
-        restore_cursor = self.__execute(
+        restore_cursor = self.__execute_server(
             f"RESTORE DATABASE ? FROM DISK = ? WITH {move_clauses}, STATS = ?;",
             [self.db_name, input_path, *move_clause_params, self.__STATS],
         )
@@ -452,7 +455,7 @@ class MsSqlProvider:
             ",".join(with_options) + ", " if len(with_options) > 0 else ""
         )
 
-        dump_cursor = self.__execute(
+        dump_cursor = self.__execute_server(
             f"BACKUP DATABASE ? TO DISK = ? WITH {with_options_str}STATS = ?;",
             [self.db_name, output_path, self.__STATS],
         )


### PR DESCRIPTION
This is very much a MSSQL-specific issue as it has to do with the interactions between the way MSSQL returns query results, ODBC and PyODBC.

Generally, when you run a query against MSSQL, using a tool such as SQL Server Management Studio, you get two output tabs, one is the 'results' and the other is 'messages'. A lot of the time, messages will show something like this:
```
(1 row affected)
```
However, if you're running an update against a table that has an update trigger on it, depending upon how that trigger is written, you'll get multiple rows like the above in the messages tab, one for the main update query and one for each update/insert/delete statement within that trigger. If you have PRINT statements in your triggers, or you're calling a stored procedure that has PRINT statements in it, then they will come back in the messages tab too.

The way that messages come back from the server is some deep, dark, low-level ODBC thing that I don't really want to have to try to understand but the important point is that PyODBC treats the data stream coming back from MSSQL as separate result sets, separated by the various messages. The outcome from all of this is that if you submit some SQL to PyODBC using Connection.execute() or Cursor.execute() then the query will stop running until Cursor.nextset() is called to get the next part of the results. 

In the context of Pynonymizer, I was running a before script to disable all my triggers as I didn't want them to run, but my before script had some print statements that listed the triggers being disabled. This resulted in not all triggers being disabled, because that before script just stopped on the first print statement. Then, all the subsequent updates from my config were running with the triggers enabled and only anonymizing some of the data.

This could be updated through documentation (e.g. to not use print statements in before and after scripts), or we could add 'SET NOCOUNT ON;' to the start of each command like you've already got with ANSI_WARNINGS, but all of that seems to me to be a bit of a hack. The fix I've included will work with any combination of triggers or print statements, so if another user wants to keep their triggers applying whatever business rules they've got setup, then the anonymization process will work for them in a predictable way.